### PR TITLE
Limit FCM credential refresh retry attempts on init

### DIFF
--- a/pushiko-fcm/src/main/kotlin/com/bloomberg/pushiko/fcm/oauth/CredentialsRefreshManager.kt
+++ b/pushiko-fcm/src/main/kotlin/com/bloomberg/pushiko/fcm/oauth/CredentialsRefreshManager.kt
@@ -37,7 +37,8 @@ import kotlinx.coroutines.cancel
 internal class CredentialsRefreshManager(
     private val credentials: ServiceAccountCredentials,
     dispatcher: CoroutineDispatcher,
-    private val backOff: BackOff = OAuthRefreshBackOff(credentials)
+    private val backOff: BackOff = OAuthRefreshBackOff(credentials),
+    private val maxInitRetries: Int = DEFAULT_MAX_INIT_RETRIES
 ) {
     private val logger = Logger()
     private val iterator = iterator {
@@ -66,10 +67,16 @@ internal class CredentialsRefreshManager(
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
 
     init {
+        var retries = 0
         while (true) {
             when (val result = iterator.next()) {
                 is RefreshResult.Success -> break
-                is RefreshResult.RetryableFailure -> Thread.sleep(initialDelay.toMillis())
+                is RefreshResult.RetryableFailure -> {
+                    if (++retries > maxInitRetries) {
+                        throw result.exception
+                    }
+                    Thread.sleep(initialDelay.toMillis())
+                }
                 is RefreshResult.PermanentFailure -> throw result.exception
             }
         }
@@ -120,5 +127,6 @@ internal class CredentialsRefreshManager(
 
     private companion object {
         val initialDelay: Duration = Duration.ofSeconds(2L)
+        const val DEFAULT_MAX_INIT_RETRIES = 5
     }
 }

--- a/pushiko-fcm/src/test/kotlin/com/bloomberg/pushiko/fcm/oauth/CredentialsRefreshManagerTest.kt
+++ b/pushiko-fcm/src/test/kotlin/com/bloomberg/pushiko/fcm/oauth/CredentialsRefreshManagerTest.kt
@@ -107,10 +107,29 @@ internal class CredentialsRefreshManagerTest {
         }
     }
 
+    @Test
+    fun initFailsAfterMaxRetries() {
+        val credentials = mock<ServiceAccountCredentials>()
+        val exception = RetryableIOException("retryable_error")
+        whenever(credentials.refresh()) doThrow exception
+        assertFailsWith<IOException> {
+            manager = CredentialsRefreshManager(credentials, Dispatchers.Unconfined, backOff)
+        }.let {
+            assertSame(exception, it)
+        }
+        verify(credentials, times(6)).refresh()
+    }
+
     private companion object {
         private const val DEFAULT_EXPIRY_MILLIS = 10_000L * 1_000L
         private const val FAKE_TOKEN = "abc123"
         private const val ANOTHER_FAKE_TOKEN = "xyz456"
+    }
+
+    private class RetryableIOException(message: String) : IOException(message), Retryable {
+        override fun isRetryable() = true
+
+        override fun getRetryCount() = 0
     }
 
     private class NonRetryableIOException(message: String) : IOException(message), Retryable {


### PR DESCRIPTION
Limit the number of OAuth credential refresh attempts during init to prevent the service from hanging indefinitely when credentials are invalid.

Previously, the init block retried forever with a 2-second sleep. Now it fails fast after 5 attempts.