### PR TITLE
Make FCM credentials manager responsive to closure during initialization

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -206,7 +206,10 @@ koverReport {
                 "io.netty.*",
                 "*.jmh_generated.*",
                 "*\$\$*",
-                "*Benchmark"
+                "*Benchmark",
+                "*Fixture",
+                "*FixtureKt*",
+                "*Test*"
             )
         }
     }

--- a/pushiko-fcm/build.gradle.kts
+++ b/pushiko-fcm/build.gradle.kts
@@ -70,6 +70,7 @@ testing {
                 implementation(libs.google.auth)
                 implementation(libs.kotlin.test.junit5)
                 implementation(libs.kotlinx.coroutines.core)
+                implementation(libs.kotlinx.coroutines.test)
                 runtimeOnly(libs.logback.classic)
             }
             targets {

--- a/pushiko-fcm/src/integrationTest/kotlin/com/bloomberg/pushiko/fcm/oauth/CredentialsRefreshManagerTest.kt
+++ b/pushiko-fcm/src/integrationTest/kotlin/com/bloomberg/pushiko/fcm/oauth/CredentialsRefreshManagerTest.kt
@@ -32,15 +32,16 @@ import java.security.KeyPairGenerator
 import java.util.Base64
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
 
 internal class CredentialsRefreshManagerTest {
     @Test
-    fun initExitsForInvalidServiceAccountAgainstRealGoogleBackend() {
+    fun initExitsForInvalidServiceAccountAgainstRealGoogleBackend() = runTest {
         assertFailsWith<IOException> {
             CredentialsRefreshManager(
                 credentials = fakeCredentials(URI.create("https://oauth2.googleapis.com/token")),
                 dispatcher = Dispatchers.IO
-            )
+            ).joinStart()
         }
     }
 
@@ -72,7 +73,7 @@ internal class CredentialsRefreshManagerTest {
     }
 
     @Test
-    fun initFailsFastOnNonRetryableLocalHttpError() {
+    fun initFailsFastOnNonRetryableLocalHttpError() = runTest {
         val body = """{"error":"invalid_grant","error_description":"Token has been expired or revoked."}""".toByteArray()
         val server = HttpServer.create(InetSocketAddress(0), 0).apply {
             createContext("/token") { exchange ->
@@ -88,7 +89,7 @@ internal class CredentialsRefreshManagerTest {
                 CredentialsRefreshManager(
                     credentials = fakeCredentials(URI.create("http://localhost:${server.address.port}/token")),
                     dispatcher = Dispatchers.IO
-                )
+                ).joinStart()
             }
         } finally {
             server.stop(0)

--- a/pushiko-fcm/src/integrationTest/kotlin/com/bloomberg/pushiko/fcm/shutdown/FcmClientSigtermProbeFixture.kt
+++ b/pushiko-fcm/src/integrationTest/kotlin/com/bloomberg/pushiko/fcm/shutdown/FcmClientSigtermProbeFixture.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Bloomberg Finance L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bloomberg.pushiko.fcm.shutdown
+
+import com.bloomberg.pushiko.fcm.FcmClient
+import java.io.File
+import java.io.OutputStreamWriter
+import java.net.ServerSocket
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.KeyPairGenerator
+import java.util.Base64
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+internal suspend fun main() {
+    val markerFile = Path.of(System.getProperty("pushiko.sigterm.marker"))
+    val tokenServer = FakeBusyTokenServerFixture().apply(FakeBusyTokenServerFixture::start)
+    val metadata = createServiceAccountMetadata(tokenServer.port)
+    val closed = AtomicBoolean(false)
+    val client = FcmClient {
+        metadata(listOf(metadata))
+        minimumConnections(0)
+    }
+    Runtime.getRuntime().addShutdownHook(Thread {
+        @Suppress("BlockingMethodInNonBlockingContext")
+        Files.writeString(markerFile, "HOOK_START\n", StandardCharsets.UTF_8)
+        runCatching {
+            runBlocking {
+                client.close()
+            }
+            closed.set(true)
+            Files.writeString(markerFile, "HOOK_START\nCLOSE_OK\n", StandardCharsets.UTF_8)
+            println("CLOSE_OK")
+        }.onFailure {
+            Files.writeString(
+                markerFile,
+                "HOOK_START\nCLOSE_FAILED:${it::class.java.name}:${it.message}\n",
+                StandardCharsets.UTF_8
+            )
+            System.err.println("CLOSE_FAILED: ${it::class.java.name}: ${it.message}")
+        }
+        tokenServer.stop()
+        metadata.delete()
+    })
+    println("READY")
+    client.joinStart()
+    withContext(Dispatchers.IO) {
+        CountDownLatch(1).await()
+    }
+    if (!closed.get()) {
+        error("Probe exited unexpectedly")
+    }
+}
+
+private class FakeBusyTokenServerFixture {
+    private val running = AtomicBoolean(true)
+    private val serverSocket = ServerSocket(0)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    val port: Int get() = serverSocket.localPort
+
+    @Suppress("Detekt.CognitiveComplexMethod")
+    fun start() {
+        scope.launch {
+            while (running.get()) {
+                val socket = runCatching(serverSocket::accept).getOrNull() ?: break
+                launch {
+                    socket.use { client ->
+                        runCatching {
+                            val reader = client.getInputStream().bufferedReader(StandardCharsets.UTF_8)
+                            var contentLength = 0
+                            while (true) {
+                                val line = reader.readLine().takeUnless(String::isNullOrEmpty) ?: break
+                                if (line.startsWith("Content-Length:", ignoreCase = true)) {
+                                    contentLength = line.substringAfter(':').trim().toIntOrNull() ?: 0
+                                }
+                            }
+                            repeat(contentLength) {
+                                if (reader.read() == -1) {
+                                    return@repeat
+                                }
+                            }
+                            OutputStreamWriter(client.getOutputStream(), StandardCharsets.UTF_8).use { writer ->
+                                writer.write("HTTP/1.1 429 OK\r\n")
+                                writer.write("Connection: close\r\n\r\n")
+                                writer.flush()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fun stop() {
+        running.set(false)
+        try {
+            serverSocket.close()
+        } finally {
+            scope.cancel()
+        }
+    }
+}
+
+private fun createServiceAccountMetadata(port: Int): File {
+    val keyPairGenerator = KeyPairGenerator.getInstance("RSA").apply {
+        initialize(2048)
+    }
+    val privateKey = keyPairGenerator.generateKeyPair().private.encoded
+    val privateKeyPem = buildString {
+        append("-----BEGIN PRIVATE KEY-----\\n")
+        append(Base64.getMimeEncoder(64, "\n".toByteArray()).encodeToString(privateKey))
+        append("\\n-----END PRIVATE KEY-----\\n")
+    }
+    val metadata = """
+        {
+          "type": "service_account",
+          "project_id": "sigterm-test-project",
+          "private_key_id": "fake-private-key-id",
+          "private_key": "$privateKeyPem",
+          "client_email": "fake-service-account@sigterm-test-project.iam.gserviceaccount.com",
+          "client_id": "1234567890",
+          "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+          "token_uri": "http://127.0.0.1:$port/token",
+          "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+          "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/fake-service-account%40sigterm-test-project.iam.gserviceaccount.com"
+        }
+    """.trimIndent()
+    val path = Files.createTempFile("fcm-sigterm-", ".json")
+    Files.writeString(path, metadata, StandardCharsets.UTF_8)
+    return path.toFile()
+}

--- a/pushiko-fcm/src/integrationTest/kotlin/com/bloomberg/pushiko/fcm/shutdown/FcmClientSigtermTest.kt
+++ b/pushiko-fcm/src/integrationTest/kotlin/com/bloomberg/pushiko/fcm/shutdown/FcmClientSigtermTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Bloomberg Finance L.P.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bloomberg.pushiko.fcm.shutdown
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+internal class FcmClientSigtermTest {
+    private val markerPath = Files.createTempFile("fcm-sigterm-marker-", ".txt").apply {
+        toFile().deleteOnExit()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        markerPath.toFile().delete()
+    }
+
+    @Test
+    fun sigtermTriggersFastClientShutdown() {
+        val javaBinary = Paths.get(System.getProperty("java.home"), "bin", "java").toString()
+        val classpath = System.getProperty("java.class.path")
+        val process = ProcessBuilder(
+            javaBinary,
+            "-Dpushiko.sigterm.marker=$markerPath",
+            "-cp",
+            classpath,
+            "com.bloomberg.pushiko.fcm.shutdown.FcmClientSigtermProbeFixtureKt"
+        ).redirectErrorStream(true).start()
+        val output = StringBuilder()
+        val ready = CountDownLatch(1)
+        val reader = thread(start = true, isDaemon = true) {
+            BufferedReader(InputStreamReader(process.inputStream, StandardCharsets.UTF_8)).useLines { lines ->
+                lines.forEach { line ->
+                    output.appendLine(line)
+                    if (line.contains("READY")) {
+                        ready.countDown()
+                    }
+                }
+            }
+        }
+        assertTrue(ready.await(15L, TimeUnit.SECONDS), "Probe did not become ready. Output:\n$output")
+        process.destroy()
+        val exited = process.waitFor(15L, TimeUnit.SECONDS)
+        if (!exited) {
+            process.destroyForcibly()
+        }
+        reader.join(2_000L)
+        val marker = Files.readString(markerPath)
+        assertTrue(exited, "Child JVM did not exit within timeout after SIGTERM. Output:\n$output")
+        assertTrue(marker.contains("HOOK_START"), "Shutdown hook did not run. Output:\n$output")
+        assertTrue(marker.contains("CLOSE_OK"), "Shutdown hook did not report successful close. " +
+            "Marker:\n$marker\nOutput:\n$output")
+    }
+}

--- a/pushiko-fcm/src/main/kotlin/com/bloomberg/pushiko/fcm/FcmClient.kt
+++ b/pushiko-fcm/src/main/kotlin/com/bloomberg/pushiko/fcm/FcmClient.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.delay
@@ -67,6 +68,8 @@ import kotlin.contracts.contract
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.toKotlinDuration
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 
 private const val FCM_HOST = "fcm.googleapis.com"
 private const val FCM_PORT = 443
@@ -128,16 +131,32 @@ class FcmClient private constructor(
     private val javaScope = CoroutineScope(SupervisorJob() + (javaDispatcher ?: CommonPoolDispatcher))
 
     /**
-     * Suspends the current coroutine until this [FcmClient] has been allowed to complete all of its initial
-     * preparation such as pre-populating its internal HTTP connection pool.
+     * Suspends the current coroutine until this [FcmClient] has completed startup preparation.
+     *
+     * This includes:
+     * - starting OAuth sessions for all configured projects;
+     * - starting credential keep-alive refresh loops, and
+     * - pre-populating the internal HTTP connection pool.
+     *
+     * Callers should await this successfully before sending notifications, otherwise requests may
+     * race with bootstrap initialization.
      *
      * @throws CancellationException if the job of the coroutine context is cancelled or completed.
      *
      * @since 0.19.0
      */
     @JvmSynthetic
-    suspend fun joinStart() {
-        httpClient.prepare()
+    suspend fun joinStart(): Unit = coroutineScope {
+        launch {
+            httpClient.prepare()
+        }
+        sessions.values.chunked(size = 8).forEach { sessions ->
+            sessions.map { session ->
+                launch {
+                    session.joinStart()
+                }
+            }.joinAll()
+        }
     }
 
     /**
@@ -231,10 +250,8 @@ class FcmClient private constructor(
             httpClient.close()
         } finally {
             sessions.entries.forEach {
-                runCatching {
-                    it.value.close()
-                }.onFailure { e ->
-                    logger.info("Error closing session {}", it.key, e)
+                it.value.runCatching(Session::close).onFailure { e ->
+                    logger.warn("Error closing session {}", it.key, e)
                 }
             }
         }

--- a/pushiko-fcm/src/main/kotlin/com/bloomberg/pushiko/fcm/oauth/CredentialsRefreshManager.kt
+++ b/pushiko-fcm/src/main/kotlin/com/bloomberg/pushiko/fcm/oauth/CredentialsRefreshManager.kt
@@ -30,15 +30,16 @@ import java.io.IOException
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 import javax.annotation.concurrent.ThreadSafe
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 
 @ThreadSafe
 internal class CredentialsRefreshManager(
     private val credentials: ServiceAccountCredentials,
     dispatcher: CoroutineDispatcher,
-    private val backOff: BackOff = OAuthRefreshBackOff(credentials),
-    private val maxInitRetries: Int = DEFAULT_MAX_INIT_RETRIES
+    private val backOff: BackOff = OAuthRefreshBackOff(credentials)
 ) {
     private val logger = Logger()
     private val iterator = iterator {
@@ -65,24 +66,43 @@ internal class CredentialsRefreshManager(
         }
     }
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
-
-    init {
-        var retries = 0
-        while (true) {
+    private val startup = scope.async(start = CoroutineStart.LAZY) {
+        while (currentCoroutineContext().isActive) {
             when (val result = iterator.next()) {
-                is RefreshResult.Success -> break
-                is RefreshResult.RetryableFailure -> {
-                    if (++retries > maxInitRetries) {
-                        throw result.exception
-                    }
-                    Thread.sleep(initialDelay.toMillis())
+                is RefreshResult.Success -> {
+                    logger.info(
+                        "Startup OAuth refresh succeeded for {}, token expires in at most {}s",
+                        credentials.projectId,
+                        result.accessToken.expiresInSeconds
+                    )
+                    return@async result.accessToken
                 }
-                is RefreshResult.PermanentFailure -> throw result.exception
+                is RefreshResult.RetryableFailure -> {
+                    logger.warn(
+                        "Startup OAuth refresh failed for {}, retrying in {}s: {}",
+                        credentials.projectId,
+                        initialDelay.seconds,
+                        result.exception.message
+                    )
+                    delay(initialDelay.toMillis())
+                }
+                is RefreshResult.PermanentFailure -> {
+                    logger.error(
+                        "Startup OAuth refresh failed permanently for {}: {}",
+                        credentials.projectId,
+                        result.exception.message
+                    )
+                    throw result.exception
+                }
             }
         }
-        scope.launch { keepAlive() }.also {
-            check(it.isActive) { "OAuth session is not being kept alive" }
-        }
+        error("OAuth startup finished without obtaining an access token")
+    }
+    private val job = scope.launch(start = CoroutineStart.LAZY) { keepAlive() }
+
+    suspend fun joinStart() {
+        startup.await()
+        job.start()
     }
 
     fun stop() {
@@ -106,10 +126,25 @@ internal class CredentialsRefreshManager(
                 TimeUnit.MILLISECONDS.toSeconds(interval)
             )
             delay(interval)
-            when (iterator.next()) {
-                is RefreshResult.Success -> backOff.reset()
-                is RefreshResult.RetryableFailure,
-                is RefreshResult.PermanentFailure -> Unit
+            when (val result = iterator.next()) {
+                is RefreshResult.Success -> {
+                    logger.info(
+                        "Keep-alive OAuth refresh succeeded for {}, token expires in at most {}s",
+                        credentials.projectId,
+                        result.accessToken.expiresInSeconds
+                    )
+                    backOff.reset()
+                }
+                is RefreshResult.RetryableFailure -> logger.warn(
+                    "Keep-alive OAuth refresh failed for {}, will retry with backoff: {}",
+                    credentials.projectId,
+                    result.exception.message
+                )
+                is RefreshResult.PermanentFailure -> logger.error(
+                    "Keep-alive OAuth refresh failed permanently for {}: {}",
+                    credentials.projectId,
+                    result.exception.message
+                )
             }
         }
         logger.info("OAuth keep-alive stopped: {} manager has been shut down", credentials.projectId)
@@ -127,6 +162,5 @@ internal class CredentialsRefreshManager(
 
     private companion object {
         val initialDelay: Duration = Duration.ofSeconds(2L)
-        const val DEFAULT_MAX_INIT_RETRIES = 5
     }
 }

--- a/pushiko-fcm/src/main/kotlin/com/bloomberg/pushiko/fcm/oauth/CredentialsSession.kt
+++ b/pushiko-fcm/src/main/kotlin/com/bloomberg/pushiko/fcm/oauth/CredentialsSession.kt
@@ -40,19 +40,30 @@ internal class CredentialsSession(
     override val sendPath = projectId.fcmSendPath()
 
     private val logger = Logger()
+    @Volatile
+    private var authorization: String? = credentials.accessToken?.tokenValue?.bearer()
+
     private val credentialsChangedListener = OAuth2Credentials.CredentialsChangedListener {
-        this@CredentialsSession.currentAuthorization = it.accessToken.tokenValue
+        this@CredentialsSession.authorization = it.accessToken.tokenValue.bearer()
         logger.info("Refreshed access token for: {}", projectId)
     }.also {
         credentials.addChangeListener(it)
     }
     private val credentialsRefresher = CredentialsRefreshManager(credentials, dispatcher)
 
-    @Volatile
-    override var currentAuthorization: String = credentials.run {
-        (accessToken ?: refreshAccessToken()).tokenValue
-    }.bearer()
-        set(value) { field = value.bearer() }
+    override val currentAuthorization: String
+        get() = requireNotNull(authorization ?: credentials.accessToken?.tokenValue?.bearer()?.also {
+            authorization = it
+        }) {
+            "FCM session '$projectId' is not started. Call joinStart() first"
+        }
+
+    override suspend fun joinStart() {
+        credentialsRefresher.joinStart()
+        authorization = requireNotNull(credentials.accessToken?.tokenValue?.bearer()) {
+            "No access token available for FCM session '$projectId' after startup"
+        }
+    }
 
     override fun close() {
         logger.info("Closing credential session, id: {}", projectId)

--- a/pushiko-fcm/src/main/kotlin/com/bloomberg/pushiko/fcm/oauth/Session.kt
+++ b/pushiko-fcm/src/main/kotlin/com/bloomberg/pushiko/fcm/oauth/Session.kt
@@ -30,4 +30,9 @@ internal sealed interface Session : Closeable {
      * @return current authorization bearer.
      */
     val currentAuthorization: String
+
+    /**
+     * Perform session bootstrap work such as obtaining an initial token and starting refresh loops.
+     */
+    suspend fun joinStart()
 }

--- a/pushiko-fcm/src/test/kotlin/com/bloomberg/pushiko/fcm/oauth/CredentialsRefreshManagerTest.kt
+++ b/pushiko-fcm/src/test/kotlin/com/bloomberg/pushiko/fcm/oauth/CredentialsRefreshManagerTest.kt
@@ -26,12 +26,15 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.IOException
 import java.util.Date
+import kotlin.concurrent.thread
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertSame
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
 import org.mockito.kotlin.doThrow
 
 internal class CredentialsRefreshManagerTest {
@@ -61,7 +64,7 @@ internal class CredentialsRefreshManagerTest {
     }
 
     @Test
-    fun refreshSuccess() {
+    fun refreshSuccess() = runTest {
         val backOff = mock<BackOff>()
         val iterator = sequence {
             yield(0L)
@@ -69,6 +72,7 @@ internal class CredentialsRefreshManagerTest {
         }.iterator()
         whenever(backOff.nextBackOffMillis()).thenAnswer { iterator.next() }
         manager = CredentialsRefreshManager(credentials, Dispatchers.Unconfined, backOff)
+        manager.joinStart()
         assertEquals(ANOTHER_FAKE_TOKEN, credentials.accessToken.tokenValue)
         verify(backOff, times(1)).reset()
     }
@@ -77,13 +81,17 @@ internal class CredentialsRefreshManagerTest {
     fun backOffCanExpire() {
         val backOff = mock<BackOff>()
         whenever(backOff.nextBackOffMillis()).thenReturn(-1L)
+        manager = CredentialsRefreshManager(credentials, Dispatchers.Unconfined, backOff)
         assertFailsWith<IllegalStateException> {
-            manager = CredentialsRefreshManager(credentials, Dispatchers.Unconfined, backOff)
+            runTest {
+                manager.joinStart()
+            }
         }
+        verify(backOff, times(1)).nextBackOffMillis()
     }
 
     @Test
-    fun initRetriesWithInitiallyNullAccessToken() {
+    fun startRetriesWithInitiallyNullAccessToken() {
         val credentials = mock<ServiceAccountCredentials>()
         val iterator = sequence {
             yield(AccessToken(FAKE_TOKEN, Date(System.currentTimeMillis() + DEFAULT_EXPIRY_MILLIS)))
@@ -92,32 +100,40 @@ internal class CredentialsRefreshManagerTest {
             whenever(credentials.accessToken).thenReturn(iterator.next())
         }
         manager = CredentialsRefreshManager(credentials, coroutineDispatcher, backOff)
+        runTest {
+            manager.joinStart()
+        }
         verify(credentials, times(1)).refresh()
     }
 
     @Test
-    fun initFailsFastWhenRefreshFailureIsNonRetryable() {
+    fun startFailsFastWhenRefreshFailureIsNonRetryable() = runTest {
         val credentials = mock<ServiceAccountCredentials>()
         val exception = NonRetryableIOException("invalid_grant")
         whenever(credentials.refresh()) doThrow exception
+        manager = CredentialsRefreshManager(credentials, Dispatchers.Unconfined, backOff)
         assertFailsWith<IOException> {
-            manager = CredentialsRefreshManager(credentials, Dispatchers.Unconfined, backOff)
+            manager.joinStart()
         }.let {
             assertSame(exception, it)
         }
     }
 
     @Test
-    fun initFailsAfterMaxRetries() {
+    fun startIsCancellable() {
         val credentials = mock<ServiceAccountCredentials>()
         val exception = RetryableIOException("retryable_error")
         whenever(credentials.refresh()) doThrow exception
-        assertFailsWith<IOException> {
-            manager = CredentialsRefreshManager(credentials, Dispatchers.Unconfined, backOff)
-        }.let {
-            assertSame(exception, it)
+        manager = CredentialsRefreshManager(credentials, Dispatchers.Unconfined, backOff)
+        thread(start = true, isDaemon = true) {
+            Thread.sleep(100L)
+            manager.stop()
         }
-        verify(credentials, times(6)).refresh()
+        assertFailsWith<CancellationException> {
+            runTest {
+                manager.joinStart()
+            }
+        }
     }
 
     private companion object {

--- a/pushiko-fcm/src/test/kotlin/com/bloomberg/pushiko/fcm/oauth/CredentialsSessionTest.kt
+++ b/pushiko-fcm/src/test/kotlin/com/bloomberg/pushiko/fcm/oauth/CredentialsSessionTest.kt
@@ -23,6 +23,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -48,7 +49,7 @@ internal class CredentialsSessionTest {
     @Test
     fun projectId() {
         assertEquals("com.bloomberg.foo", session.projectId)
-        verify(credentials, times(2)).projectId
+        verify(credentials, times(1)).projectId
     }
 
     @Test
@@ -57,5 +58,15 @@ internal class CredentialsSessionTest {
             assertEquals("Bearer xyz", session.currentAuthorization)
         }
         verify(credentials, atLeastOnce()).accessToken
+    }
+
+    @Test
+    fun constructorDoesNotRefreshCredentials() {
+        val credentials = mock<ServiceAccountCredentials>().apply {
+            whenever(projectId) doReturn "com.bloomberg.foo"
+            whenever(accessToken) doReturn null
+        }
+        CredentialsSession(credentials, dispatcher)
+        verify(credentials, never()).refreshAccessToken()
     }
 }


### PR DESCRIPTION
Move the FCM session initialization out of init and behind .joinStart which must complete successfully before the server goes online.

FcmClient is now fully responsive when the JVM receives SIGTERM.